### PR TITLE
Fix conversion of hoomd box to vmd

### DIFF
--- a/gsdplugin.c
+++ b/gsdplugin.c
@@ -841,17 +841,19 @@ static int read_gsd_timestep(void *mydata, int natoms, molfile_timestep_t *ts)
             }
         else
             {
-            // define lattice constants in terms of box size and tilt factors
-            const double xy = (double)box[3];
-            const double xz = (double)box[4];
-            const double yz = (double)box[5];
-            const double norm1 = sqrt(1.0 + xy*xy);
-            const double norm2 = sqrt(1.0 + xz*xz + yz*yz);
-            
-            ts->A = box[0]; ts->B = (float)norm1*box[1]; ts->C = (float)norm2*box[2];
-            
             if (box[3] != 0.0f || box[4] != 0.0f || box[5] != 0.0f)
                 {
+                // define lattice constants in terms of box size and tilt factors
+                const double xy = (double)box[3];
+                const double xz = (double)box[4];
+                const double yz = (double)box[5];
+                const double norm1 = sqrt(1.0 + xy*xy);
+                const double norm2 = sqrt(1.0 + xz*xz + yz*yz);
+
+                ts->A = box[0];
+                ts->B = (float)(norm1*box[1]);
+                ts->C = (float)(norm2*box[2]);
+                
                 // need to resolve the tilt factors into angles
                 const double cos_gamma= xy / norm1;
                 const double cos_beta = xz / norm2;
@@ -863,6 +865,7 @@ static int read_gsd_timestep(void *mydata, int natoms, molfile_timestep_t *ts)
                 }
             else // orthorhombic
                 {
+                ts->A = box[0]; ts->B = box[1]; ts->C = box[2];
                 ts->alpha = 90.0f; ts->beta = 90.0f; ts->gamma = 90.0f;
                 }
             }

--- a/gsdplugin.c
+++ b/gsdplugin.c
@@ -842,17 +842,17 @@ static int read_gsd_timestep(void *mydata, int natoms, molfile_timestep_t *ts)
         else
             {
             // define lattice constants in terms of box size and tilt factors
-            ts->A = box[0]; ts->B = (1.0 + box[3])*box[1]; ts->C = (1.0 + box[4] + box[5])*box[2];
+            const double xy = (double)box[3];
+            const double xz = (double)box[4];
+            const double yz = (double)box[5];
+            const double norm1 = sqrt(1.0 + xy*xy);
+            const double norm2 = sqrt(1.0 + xz*xz + yz*yz);
+            
+            ts->A = box[0]; ts->B = (float)norm1*box[1]; ts->C = (float)norm2*box[2];
             
             if (box[3] != 0.0f || box[4] != 0.0f || box[5] != 0.0f)
                 {
                 // need to resolve the tilt factors into angles
-                const double xy = (double)box[3];
-                const double xz = (double)box[4];
-                const double yz = (double)box[5];
-                const double norm1 = sqrt(1.0 + xy*xy);
-                const double norm2 = sqrt(1.0 + xz*xz + yz*yz);
-
                 const double cos_gamma= xy / norm1;
                 const double cos_beta = xz / norm2;
                 const double cos_alpha = (xy*xz + yz)/(norm1 * norm2);

--- a/gsdplugin.c
+++ b/gsdplugin.c
@@ -841,7 +841,9 @@ static int read_gsd_timestep(void *mydata, int natoms, molfile_timestep_t *ts)
             }
         else
             {
-            ts->A = box[0]; ts->B = box[1]; ts->C = box[2];
+            // define lattice constants in terms of box size and tilt factors
+            ts->A = box[0]; ts->B = (1.0 + box[3])*box[1]; ts->C = (1.0 + box[4] + box[5])*box[2];
+            
             if (box[3] != 0.0f || box[4] != 0.0f || box[5] != 0.0f)
                 {
                 // need to resolve the tilt factors into angles


### PR DESCRIPTION
I think the vmd lattice constants (if A, B, and C are indeed lattice constants) should also involve the tilt factors, consistent with HOOMD's definition: https://hoomd-blue.readthedocs.io/en/stable/box.html. (I noticed in some shear simulations that the box looked too small in the gradient direction!)